### PR TITLE
Ssh flags support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # smart-ssh
 
+## Usage
+
+```zsh
+alias s='smart-ssh -XYt -ls.seletskiy'
+```
 
 ## Options
-
-` zstyle ':smart-ssh' username e.kovetskiy `
-
-` zstyle ':smart-ssh' ssh-options '-t' 'TERM=xterm sudo -i' `
 
 ` zstyle ':smart-ssh' whitelist '.s' '.in.ngs.ru' `

--- a/plugin.zsh
+++ b/plugin.zsh
@@ -46,7 +46,7 @@ _smash_set_counter() {
 
     local dir=$(_smash_get_option counters ~/.ssh/counters/)
 
-    echo -n "$value" > "$dir/$hostname"
+    echo -n "$value" >! "$dir/$hostname"
 }
 
 _smash_remove_counter() {

--- a/plugin.zsh
+++ b/plugin.zsh
@@ -31,10 +31,10 @@ _smash_get_counter() {
     local hostname="$1"
 
     local dir=$(_smash_get_option counters ~/.ssh/counters/)
-    [ ! -d "$dir" ] && /bin/mkdir -p "$dir"
+    /bin/mkdir -p "$dir"
 
     local file="$dir/$hostname"
-    [ ! -f "$file" ] && touch "$file"
+    touch "$file"
 
     local counter=$(cat "$file")
     echo "${counter:-0}"
@@ -61,7 +61,7 @@ _smash_is_synced_hostname() {
     local hostname="$1"
 
     local dir=$(_smash_get_option syncs ~/.ssh/syncs/)
-    [ ! -d "$dir" ] && /bin/mkdir -p "$dir"
+    /bin/mkdir -p "$dir"
 
     [ -f "$dir/$hostname" ]
     return $?
@@ -71,7 +71,7 @@ _smash_set_synced() {
     local hostname="$1"
 
     local dir=$(_smash_get_option syncs ~/.ssh/syncs/)
-    [ ! -d "$dir" ] && /bin/mkdir -p "$dir"
+    /bin/mkdir -p "$dir"
 
     touch "$dir/$hostname"
 }


### PR DESCRIPTION
It will make smart-ssh work as drop-in ssh replacement with supporting all flags user can pass. Also, it's possible to specify identity file to copy on the remote host (`-i` flag).
